### PR TITLE
Tron Send Fixes

### DIFF
--- a/android/src/main/kotlin/africa/ejara/trustdart/coins/TRX.kt
+++ b/android/src/main/kotlin/africa/ejara/trustdart/coins/TRX.kt
@@ -99,6 +99,7 @@ class TRX : Coin("TRX", CoinType.TRON) {
                     .setTimestamp(txData["timestamp"] as Long)
                     .setTransfer(transfer)
                     .setBlockHeader(blockHeader)
+                    .setFeeLimit((txData["feeLimit"] as Int).toLong())
                     .build()
 
                 val signingInput = Tron.SigningInput.newBuilder()

--- a/android/src/main/kotlin/africa/ejara/trustdart/coins/TRX.kt
+++ b/android/src/main/kotlin/africa/ejara/trustdart/coins/TRX.kt
@@ -36,10 +36,10 @@ class TRX : Coin("TRX", CoinType.TRON) {
                     .build()
 
                 val transaction = Tron.Transaction.newBuilder()
-                    .setTimestamp(txData["timestamp"] as Long)
                     .setTransferTrc20Contract(trc20Contract)
-                    .setBlockHeader(blockHeader)
+                    .setTimestamp(txData["timestamp"] as Long)
                     .setFeeLimit((txData["feeLimit"] as Int).toLong())
+                    .setBlockHeader(blockHeader)
                     .build()
 
                 val signingInput = Tron.SigningInput.newBuilder()
@@ -67,8 +67,8 @@ class TRX : Coin("TRX", CoinType.TRON) {
                     .build()
 
                 val transaction = Tron.Transaction.newBuilder()
-                    .setTimestamp(txData["timestamp"] as Long)
                     .setTransferAsset(trc10Contract)
+                    .setTimestamp(txData["timestamp"] as Long)
                     .setBlockHeader(blockHeader)
                     .build()
 
@@ -97,9 +97,9 @@ class TRX : Coin("TRX", CoinType.TRON) {
 
                 val transaction = Tron.Transaction.newBuilder()
                     .setTimestamp(txData["timestamp"] as Long)
+                    .setFeeLimit((txData["feeLimit"] as Int).toLong())
                     .setTransfer(transfer)
                     .setBlockHeader(blockHeader)
-                    .setFeeLimit((txData["feeLimit"] as Int).toLong())
                     .build()
 
                 val signingInput = Tron.SigningInput.newBuilder()

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/ios/Classes/coins/TRX.swift
+++ b/ios/Classes/coins/TRX.swift
@@ -28,8 +28,8 @@ class TRX: Coin  {
                     
                     let input = TronSigningInput.with {
                         $0.transaction = TronTransaction.with {
-                            $0.feeLimit = txData["feeLimit"] as! Int64
                             $0.transferTrc20Contract = contract
+                            $0.feeLimit = txData["feeLimit"] as! Int64
                             $0.timestamp = txData["timestamp"] as! Int64
                             $0.blockHeader = TronBlockHeader.with {
                                 $0.timestamp = txData["blockTime"] as! Int64
@@ -77,6 +77,7 @@ class TRX: Coin  {
                 let input = TronSigningInput.with {
                     $0.transaction = TronTransaction.with {
                         $0.transfer = transfer
+                        $0.feeLimit = txData["feeLimit"] as! Int64
                         $0.timestamp = txData["timestamp"] as! Int64
                         $0.blockHeader = TronBlockHeader.with {
                             $0.timestamp = txData["blockTime"] as! Int64


### PR DESCRIPTION
1. Updated the gradle version in Android.
2. Reverted to adding the `feeLimit` option in TRON (TRX). For instance, it provides the flexibility of setting the `feeLimit` to `0` for TRX send. 